### PR TITLE
Handle Supabase numeric strings safely

### DIFF
--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -1,7 +1,9 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+const viteEnv = (typeof import.meta !== 'undefined' ? (import.meta as { env?: Record<string, string | undefined> }).env : undefined) || {}
+
+const supabaseUrl = viteEnv.VITE_SUPABASE_URL ?? process.env.VITE_SUPABASE_URL
+const supabaseAnonKey = viteEnv.VITE_SUPABASE_ANON_KEY ?? process.env.VITE_SUPABASE_ANON_KEY
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase environment variables')

--- a/src/services/supabase/expenses.ts
+++ b/src/services/supabase/expenses.ts
@@ -1,6 +1,12 @@
 import { supabase } from '../../config/supabase'
 import type { Expense } from './types'
 import logger from '../../utils/logger'
+import { ensureNumber } from './numeric'
+
+const normalizeExpense = (expense: Expense): Expense => ({
+  ...expense,
+  amount: ensureNumber((expense as unknown as { amount: unknown }).amount)
+})
 
 export const expenseService = {
   async create(expenseData: Omit<Expense, 'id' | 'created_at' | 'updated_at'>): Promise<Expense> {
@@ -14,7 +20,7 @@ export const expenseService = {
       if (error) throw error
       
       logger.info('Expense created successfully', { id: data.id })
-      return data
+      return normalizeExpense(data)
     } catch (error) {
       logger.error('Failed to create expense', error)
       throw error
@@ -30,7 +36,7 @@ export const expenseService = {
         .single()
 
       if (error && error.code !== 'PGRST116') throw error
-      return data || null
+      return data ? normalizeExpense(data) : null
     } catch (error) {
       logger.error('Failed to get expense by ID', error)
       throw error
@@ -46,7 +52,7 @@ export const expenseService = {
         .order('date', { ascending: false })
 
       if (error) throw error
-      return data || []
+      return (data || []).map(normalizeExpense)
     } catch (error) {
       logger.error('Failed to get expenses by property ID', error)
       throw error
@@ -62,7 +68,7 @@ export const expenseService = {
         .order('date', { ascending: false })
 
       if (error) throw error
-      return data || []
+      return (data || []).map(normalizeExpense)
     } catch (error) {
       logger.error('Failed to get expenses by user ID', error)
       throw error

--- a/src/services/supabase/numeric.ts
+++ b/src/services/supabase/numeric.ts
@@ -1,0 +1,22 @@
+export function ensureNumber(value: unknown): number {
+  if (typeof value === 'number') {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.replace(/\s+/g, '').replace(',', '.')
+    const parsed = Number(normalized)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+
+  if (typeof value === 'bigint') {
+    return Number(value)
+  }
+
+  if (value instanceof Number) {
+    return value.valueOf()
+  }
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}

--- a/src/services/supabase/revenues.ts
+++ b/src/services/supabase/revenues.ts
@@ -1,6 +1,12 @@
 import { supabase } from '../../config/supabase'
 import type { Revenue } from './types'
 import logger from '../../utils/logger'
+import { ensureNumber } from './numeric'
+
+const normalizeRevenue = (revenue: Revenue): Revenue => ({
+  ...revenue,
+  amount: ensureNumber((revenue as unknown as { amount: unknown }).amount)
+})
 
 export const revenueService = {
   async create(revenueData: Omit<Revenue, 'id' | 'created_at' | 'updated_at'>): Promise<Revenue> {
@@ -14,7 +20,7 @@ export const revenueService = {
       if (error) throw error
       
       logger.info('Revenue created successfully', { id: data.id })
-      return data
+      return normalizeRevenue(data)
     } catch (error) {
       logger.error('Failed to create revenue', error)
       throw error
@@ -30,7 +36,7 @@ export const revenueService = {
         .single()
 
       if (error && error.code !== 'PGRST116') throw error
-      return data || null
+      return data ? normalizeRevenue(data) : null
     } catch (error) {
       logger.error('Failed to get revenue by ID', error)
       throw error
@@ -46,7 +52,7 @@ export const revenueService = {
         .order('date', { ascending: false })
 
       if (error) throw error
-      return data || []
+      return (data || []).map(normalizeRevenue)
     } catch (error) {
       logger.error('Failed to get revenues by property ID', error)
       throw error
@@ -62,7 +68,7 @@ export const revenueService = {
         .order('date', { ascending: false })
 
       if (error) throw error
-      return data || []
+      return (data || []).map(normalizeRevenue)
     } catch (error) {
       logger.error('Failed to get revenues by user ID', error)
       throw error

--- a/src/services/supabase/utils.test.ts
+++ b/src/services/supabase/utils.test.ts
@@ -1,0 +1,305 @@
+import assert from 'node:assert/strict'
+import { mock, test } from 'node:test'
+
+import type { Amortization, Declaration, Expense, Revenue } from './types'
+
+process.env.VITE_SUPABASE_URL ??= 'https://example.supabase.co'
+process.env.VITE_SUPABASE_ANON_KEY ??= 'test-key'
+
+const { getUserDashboardData } = await import('./utils.ts')
+const { revenueService } = await import('./revenues.ts')
+const { expenseService } = await import('./expenses.ts')
+const { declarationService } = await import('./declarations.ts')
+const { amortizationService } = await import('./amortizations.ts')
+const { propertyService } = await import('./properties.ts')
+const { notificationService } = await import('./notifications.ts')
+const { userService } = await import('./users.ts')
+const { supabase } = await import('../../config/supabase.ts')
+
+interface SupabaseResponse<T> {
+  data: T
+  error: null
+}
+
+test('getUserDashboardData calcule les totaux avec des montants en chaînes', async () => {
+  const properties = [
+    { id: 'property-1' }
+  ]
+
+  const revenues: Revenue[] = [
+    {
+      id: 'rev-1',
+      user_id: 'user-1',
+      property_id: 'property-1',
+      amount: '1000.50',
+      date: '2023-01-15',
+      description: 'Loyer',
+      type: 'rent',
+      created_at: '2023-01-15',
+      updated_at: '2023-01-15'
+    } as unknown as Revenue,
+    {
+      id: 'rev-2',
+      user_id: 'user-1',
+      property_id: 'property-1',
+      amount: '500.25',
+      date: '2023-02-15',
+      description: 'Charges',
+      type: 'charges',
+      created_at: '2023-02-15',
+      updated_at: '2023-02-15'
+    } as unknown as Revenue
+  ]
+
+  const expenses: Expense[] = [
+    {
+      id: 'exp-1',
+      user_id: 'user-1',
+      property_id: 'property-1',
+      amount: '200.25',
+      date: '2023-01-20',
+      description: 'Entretien',
+      category: 'maintenance',
+      deductible: true,
+      created_at: '2023-01-20',
+      updated_at: '2023-01-20'
+    } as unknown as Expense,
+    {
+      id: 'exp-2',
+      user_id: 'user-1',
+      property_id: 'property-1',
+      amount: '100',
+      date: '2023-02-20',
+      description: 'Assurance',
+      category: 'insurance',
+      deductible: true,
+      created_at: '2023-02-20',
+      updated_at: '2023-02-20'
+    } as unknown as Expense
+  ]
+
+  const declarations: Declaration[] = []
+  const notifications = []
+
+  const propertyMock = mock.method(propertyService, 'getByUserId', async () => properties as any)
+  const declarationMock = mock.method(declarationService, 'getByUserId', async () => declarations)
+  const revenueMock = mock.method(revenueService, 'getByUserId', async () => revenues)
+  const expenseMock = mock.method(expenseService, 'getByUserId', async () => expenses)
+  const notificationMock = mock.method(notificationService, 'getByUserId', async () => notifications as any)
+  const updateStatsMock = mock.method(userService, 'updateStats', async () => {})
+
+  try {
+    const dashboard = await getUserDashboardData('user-1')
+
+    assert.equal(dashboard.stats.totalRevenue, 1500.75)
+    assert.equal(dashboard.stats.totalExpenses, 300.25)
+    assert.equal(dashboard.stats.netProfit, 1200.5)
+  } finally {
+    propertyMock.mock.restore()
+    declarationMock.mock.restore()
+    revenueMock.mock.restore()
+    expenseMock.mock.restore()
+    notificationMock.mock.restore()
+    updateStatsMock.mock.restore()
+  }
+})
+
+function createQuery<T>(response: SupabaseResponse<T>) {
+  return {
+    select() {
+      return this
+    },
+    eq() {
+      return this
+    },
+    order() {
+      return Promise.resolve(response)
+    },
+    single() {
+      return Promise.resolve(response)
+    },
+    then(onFulfilled: (value: SupabaseResponse<T>) => unknown, onRejected?: (reason: unknown) => unknown) {
+      return Promise.resolve(response).then(onFulfilled, onRejected)
+    }
+  }
+}
+
+test('revenueService.getByPropertyId convertit les montants en nombres', async () => {
+  const queryResponse: SupabaseResponse<Revenue[]> = {
+    data: [
+      {
+        id: 'rev-1',
+        user_id: 'user-1',
+        property_id: 'property-1',
+        amount: '1200.40',
+        date: '2023-03-01',
+        description: 'Loyer',
+        type: 'rent',
+        created_at: '2023-03-01',
+        updated_at: '2023-03-01'
+      } as unknown as Revenue,
+      {
+        id: 'rev-2',
+        user_id: 'user-1',
+        property_id: 'property-1',
+        amount: '99.6',
+        date: '2023-04-01',
+        description: 'Autre',
+        type: 'other',
+        created_at: '2023-04-01',
+        updated_at: '2023-04-01'
+      } as unknown as Revenue
+    ],
+    error: null
+  }
+
+  const fromMock = mock.method(supabase, 'from', (table: string) => {
+    assert.equal(table, 'revenues')
+    return createQuery(queryResponse)
+  })
+
+  try {
+    const result = await revenueService.getByPropertyId('property-1')
+    assert.deepEqual(result.map(revenue => revenue.amount), [1200.4, 99.6])
+  } finally {
+    fromMock.mock.restore()
+  }
+})
+
+test('expenseService.getByPropertyId convertit les montants en nombres', async () => {
+  const queryResponse: SupabaseResponse<Expense[]> = {
+    data: [
+      {
+        id: 'exp-1',
+        user_id: 'user-1',
+        property_id: 'property-1',
+        amount: '45.5',
+        date: '2023-03-10',
+        description: 'Entretien',
+        category: 'maintenance',
+        deductible: true,
+        created_at: '2023-03-10',
+        updated_at: '2023-03-10'
+      } as unknown as Expense
+    ],
+    error: null
+  }
+
+  const fromMock = mock.method(supabase, 'from', (table: string) => {
+    assert.equal(table, 'expenses')
+    return createQuery(queryResponse)
+  })
+
+  try {
+    const result = await expenseService.getByPropertyId('property-1')
+    assert.deepEqual(result.map(expense => expense.amount), [45.5])
+  } finally {
+    fromMock.mock.restore()
+  }
+})
+
+test('declarationService.getByUserId normalise les totaux numériques', async () => {
+  const queryResponse: SupabaseResponse<Declaration[]> = {
+    data: [
+      {
+        id: 'dec-1',
+        user_id: 'user-1',
+        year: 2023,
+        status: 'draft',
+        total_revenue: '2000.5',
+        total_expenses: '800.25',
+        net_result: '1200.25',
+        properties: ['property-1'],
+        documents: [],
+        details: {
+          created_automatically: true,
+          description: 'Test',
+          regime: 'real',
+          first_declaration: false
+        },
+        created_at: '2023-05-01',
+        updated_at: '2023-05-01'
+      } as unknown as Declaration
+    ],
+    error: null
+  }
+
+  const fromMock = mock.method(supabase, 'from', (table: string) => {
+    assert.equal(table, 'declarations')
+    return createQuery(queryResponse)
+  })
+
+  try {
+    const result = await declarationService.getByUserId('user-1')
+    assert.deepEqual(
+      result.map(declaration => ({
+        total_revenue: declaration.total_revenue,
+        total_expenses: declaration.total_expenses,
+        net_result: declaration.net_result
+      })),
+      [
+        {
+          total_revenue: 2000.5,
+          total_expenses: 800.25,
+          net_result: 1200.25
+        }
+      ]
+    )
+  } finally {
+    fromMock.mock.restore()
+  }
+})
+
+test('amortizationService.calculateAnnualAmortization additionne les montants numériques', async () => {
+  const queryResponse: SupabaseResponse<Amortization[]> = {
+    data: [
+      {
+        id: 'amo-1',
+        user_id: 'user-1',
+        property_id: 'property-1',
+        item_name: 'Équipement',
+        category: 'mobilier',
+        purchase_date: '2022-01-01',
+        purchase_amount: '1000',
+        useful_life_years: 5,
+        annual_amortization: '200',
+        accumulated_amortization: '200',
+        remaining_value: '800',
+        status: 'active',
+        notes: '',
+        created_at: '2022-01-01',
+        updated_at: '2022-01-01'
+      } as unknown as Amortization,
+      {
+        id: 'amo-2',
+        user_id: 'user-1',
+        property_id: 'property-1',
+        item_name: 'Amélioration',
+        category: 'travaux',
+        purchase_date: '2021-01-01',
+        purchase_amount: '2000',
+        useful_life_years: 10,
+        annual_amortization: '200.5',
+        accumulated_amortization: '401',
+        remaining_value: '1599',
+        status: 'active',
+        notes: '',
+        created_at: '2021-01-01',
+        updated_at: '2021-01-01'
+      } as unknown as Amortization
+    ],
+    error: null
+  }
+
+  const fromMock = mock.method(supabase, 'from', (table: string) => {
+    assert.equal(table, 'amortizations')
+    return createQuery(queryResponse)
+  })
+
+  try {
+    const result = await amortizationService.calculateAnnualAmortization('property-1', 2023)
+    assert.equal(result, 400.5)
+  } finally {
+    fromMock.mock.restore()
+  }
+})

--- a/src/services/supabase/utils.ts
+++ b/src/services/supabase/utils.ts
@@ -6,6 +6,7 @@ import { expenseService } from './expenses'
 import { notificationService } from './notifications'
 import type { UserProfile, DashboardData, DashboardStats } from './types'
 import logger from '../../utils/logger'
+import { ensureNumber } from './numeric'
 
 /**
  * Initialise le profil utilisateur s'il n'existe pas déjà
@@ -70,8 +71,8 @@ export async function getUserDashboardData(userId: string): Promise<DashboardDat
     ])
 
     // Calculer les statistiques
-    const totalRevenue = revenues.reduce((sum, revenue) => sum + revenue.amount, 0)
-    const totalExpenses = expenses.reduce((sum, expense) => sum + expense.amount, 0)
+    const totalRevenue = revenues.reduce((sum, revenue) => sum + ensureNumber((revenue as { amount: unknown }).amount), 0)
+    const totalExpenses = expenses.reduce((sum, expense) => sum + ensureNumber((expense as { amount: unknown }).amount), 0)
     const netProfit = totalRevenue - totalExpenses
 
     const stats: DashboardStats = {


### PR DESCRIPTION
## Summary
- add a numeric coercion helper and reuse it across Supabase services so amounts returned as strings are converted to numbers
- ensure single-record fetches and dashboard aggregation logic use the helper to avoid string concatenation bugs
- add a Node-based test suite that mocks Supabase responses to verify dashboard totals and per-page helpers with string amounts
- allow Supabase configuration to fall back to process environment variables for test environments

## Testing
- node --import=tsx --test src/services/supabase/utils.test.ts
- npm test *(fails: vitest binary unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2759630f08325a763d9856f9d193e