### PR TITLE
Fix Supabase smoke test migrations for Supabase runner

### DIFF
--- a/supabase/migrations/20250923063120_stark_desert.sql
+++ b/supabase/migrations/20250923063120_stark_desert.sql
@@ -9,9 +9,10 @@
   5. Aucune fonction uid() problématique ne subsiste
 */
 
--- Configuration pour les tests
-\set ON_ERROR_STOP on
-\timing on
+-- Les tests sont exécutés dans le cadre des migrations Supabase qui arrêtent
+-- automatiquement l'exécution en cas d'erreur. Les méta-commandes psql comme
+-- `\set ON_ERROR_STOP on` ou `\timing on` ont été supprimées pour conserver
+-- une compatibilité totale avec l'exécution des migrations côté serveur.
 
 -- Header du test
 SELECT 

--- a/supabase/migrations/20250923063155_dark_morning.sql
+++ b/supabase/migrations/20250923063155_dark_morning.sql
@@ -11,8 +11,9 @@
   3. Documente les actions effectuées
 */
 
--- Configuration
-\set ON_ERROR_STOP on
+-- Les méta-commandes psql comme `\set ON_ERROR_STOP on` ne sont pas supportées
+-- par l'exécution des migrations Supabase. Elles ont été supprimées car le
+-- moteur arrête déjà l'exécution en cas d'erreur.
 
 -- Header
 SELECT 

--- a/supabase/migrations/20250923064121_lively_tree.sql
+++ b/supabase/migrations/20250923064121_lively_tree.sql
@@ -2,14 +2,13 @@
 -- SCRIPT DE SMOKE TEST - UUID + AMORTIZATION
 -- =============================================
 
-\echo '=== SMOKE TEST UUID + AMORTIZATION ==='
-\echo ''
+SELECT '=== SMOKE TEST UUID + AMORTIZATION ===' AS info;
 
 -- =============================================
 -- 1. VÉRIFICATIONS EXTENSIONS
 -- =============================================
 
-\echo '1. Vérification des extensions:'
+SELECT '1. Vérification des extensions:' AS info;
 SELECT 
     extname as extension_name,
     extversion as version
@@ -17,25 +16,23 @@ FROM pg_extension
 WHERE extname IN ('pgcrypto', 'uuid-ossp')
 ORDER BY extname;
 
-\echo ''
 
 -- =============================================
 -- 2. TEST GÉNÉRATION UUID
 -- =============================================
 
-\echo '2. Test génération UUID:'
+SELECT '2. Test génération UUID:' AS info;
 SELECT 
     'gen_random_uuid()' as function_name,
     gen_random_uuid() as generated_uuid,
     length(gen_random_uuid()::text) as uuid_length;
 
-\echo ''
 
 -- =============================================
 -- 3. VÉRIFICATION DEFAULT COLUMNS
 -- =============================================
 
-\echo '3. Vérification des DEFAULT sur colonnes id:'
+SELECT '3. Vérification des DEFAULT sur colonnes id:' AS info;
 SELECT 
     table_name,
     column_name,
@@ -47,13 +44,12 @@ AND column_name = 'id'
 AND data_type = 'uuid'
 ORDER BY table_name;
 
-\echo ''
 
 -- =============================================
 -- 4. RECHERCHE uid() PROBLÉMATIQUES
 -- =============================================
 
-\echo '4. Recherche de uid() problématiques (hors auth.uid()):'
+SELECT '4. Recherche de uid() problématiques (hors auth.uid()):' AS info;
 SELECT 
     table_name,
     column_name,
@@ -63,17 +59,15 @@ WHERE table_schema = 'public'
 AND column_default LIKE '%uid()%'
 AND column_default NOT LIKE '%auth.uid()%';
 
-\echo ''
 
 -- =============================================
 -- 5. TEST AMORTIZATION - DIVISION PAR ZÉRO
 -- =============================================
 
-\echo '5. Test amortization avec useful_life_years = 0 (ne doit pas planter):'
+SELECT '5. Test amortization avec useful_life_years = 0 (ne doit pas planter):' AS info;
 
--- Récupérer des IDs existants pour le test
-\set test_user_id (SELECT user_id FROM public.users LIMIT 1)
-\set test_property_id (SELECT id FROM public.properties LIMIT 1)
+-- Les identifiants nécessaires sont récupérés directement via les requêtes
+-- SELECT ci-dessous afin d'éviter l'usage de méta-commandes psql.
 
 -- Test avec years=0 -> ne doit PAS lever d'erreur division par zéro
 INSERT INTO public.amortizations (
@@ -103,13 +97,12 @@ RETURNING
     annual_expense,
     annual_amortization;
 
-\echo ''
 
 -- =============================================
 -- 6. TEST AMORTIZATION - CAS NORMAL
 -- =============================================
 
-\echo '6. Test amortization avec useful_life_years = 10 (cas normal):'
+SELECT '6. Test amortization avec useful_life_years = 10 (cas normal):' AS info;
 
 INSERT INTO public.amortizations (
     user_id, 
@@ -139,13 +132,12 @@ RETURNING
     annual_amortization,
     annual_expense;
 
-\echo ''
 
 -- =============================================
 -- 7. VÉRIFICATION CONTRAINTES
 -- =============================================
 
-\echo '7. Vérification des contraintes sur amortizations:'
+SELECT '7. Vérification des contraintes sur amortizations:' AS info;
 SELECT 
     conname as constraint_name,
     contype as constraint_type,
@@ -155,13 +147,12 @@ WHERE conrelid = 'public.amortizations'::regclass
 AND contype = 'c'  -- CHECK constraints
 ORDER BY conname;
 
-\echo ''
 
 -- =============================================
 -- 8. TEST INSERT SANS ID (AUTO-GÉNÉRATION)
 -- =============================================
 
-\echo '8. Test insert sans id explicite (auto-génération UUID):'
+SELECT '8. Test insert sans id explicite (auto-génération UUID):' AS info;
 
 -- Test sur table properties (doit générer un UUID automatiquement)
 INSERT INTO public.properties (
@@ -183,13 +174,12 @@ RETURNING
     address,
     'UUID auto-généré' as status;
 
-\echo ''
 
 -- =============================================
 -- 9. NETTOYAGE DES DONNÉES DE TEST
 -- =============================================
 
-\echo '9. Nettoyage des données de test:'
+SELECT '9. Nettoyage des données de test:' AS info;
 
 DELETE FROM public.amortizations 
 WHERE item_name LIKE 'SMOKE TEST%';
@@ -199,7 +189,5 @@ WHERE address LIKE 'SMOKE TEST%';
 
 SELECT 'Données de test nettoyées' as cleanup_status;
 
-\echo ''
-\echo '=== SMOKE TEST TERMINÉ ==='
-\echo ''
-\echo 'Si aucune erreur ci-dessus, la migration UUID + amortization est OK !'
+SELECT '=== SMOKE TEST TERMINÉ ===' AS info;
+SELECT 'Si aucune erreur ci-dessus, la migration UUID + amortization est OK !' AS info;

--- a/supabase/migrations/20250923064553_ancient_bonus.sql
+++ b/supabase/migrations/20250923064553_ancient_bonus.sql
@@ -1,10 +1,10 @@
 -- Script de smoke test : UUID + Amortization
 -- Vérifie que tous les garde-fous sont en place et fonctionnels
 
-\echo '=== SMOKE TEST UUID + AMORTIZATION ==='
+SELECT '=== SMOKE TEST UUID + AMORTIZATION ===' AS info;
 
 -- 1. Vérifier l'extension pgcrypto
-\echo '1. Vérification extension pgcrypto:'
+SELECT '1. Vérification extension pgcrypto:' AS info;
 SELECT 
     CASE WHEN EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pgcrypto')
     THEN '✅ pgcrypto activée'
@@ -12,13 +12,13 @@ SELECT
     END as status;
 
 -- 2. Vérifier gen_random_uuid() fonctionne
-\echo '2. Test génération UUID:'
+SELECT '2. Test génération UUID:' AS info;
 SELECT 
     gen_random_uuid() as test_uuid,
     '✅ gen_random_uuid() fonctionnel' as status;
 
 -- 3. Vérifier les DEFAULT sur colonnes id uuid
-\echo '3. Vérification DEFAULT gen_random_uuid():'
+SELECT '3. Vérification DEFAULT gen_random_uuid():' AS info;
 SELECT 
     table_name,
     column_name,
@@ -33,7 +33,7 @@ WHERE table_schema = 'public'
 ORDER BY table_name;
 
 -- 4. Vérifier qu'aucun uid() problématique ne reste
-\echo '4. Vérification absence de uid() problématique:'
+SELECT '4. Vérification absence de uid() problématique:' AS info;
 SELECT 
     CASE WHEN EXISTS (
         SELECT 1 FROM information_schema.columns 
@@ -45,7 +45,7 @@ SELECT
     END as status;
 
 -- 5. Test amortization avec useful_life_years = 0 (doit être rejeté par contrainte)
-\echo '5. Test contrainte useful_life_years >= 1:'
+SELECT '5. Test contrainte useful_life_years >= 1:' AS info;
 DO $$
 DECLARE
     test_user_id UUID;
@@ -91,7 +91,7 @@ BEGIN
 END $$;
 
 -- 6. Test amortization avec useful_life_years = 10 (doit fonctionner)
-\echo '6. Test amortization valide (years=10):'
+SELECT '6. Test amortization valide (years=10):' AS info;
 DO $$
 DECLARE
     test_user_id UUID;
@@ -151,7 +151,7 @@ BEGIN
 END $$;
 
 -- 7. Vérifier les contraintes de qualité
-\echo '7. Vérification contraintes de qualité:'
+SELECT '7. Vérification contraintes de qualité:' AS info;
 SELECT 
     constraint_name,
     '✅ Contrainte active: ' || pg_get_constraintdef(oid) as status
@@ -160,7 +160,7 @@ WHERE conrelid = 'public.amortizations'::regclass
   AND constraint_name LIKE '%years%';
 
 -- 8. Test auto-génération UUID sur INSERT sans id
-\echo '8. Test auto-génération UUID:'
+SELECT '8. Test auto-génération UUID:' AS info;
 DO $$
 DECLARE
     test_user_id UUID;
@@ -208,11 +208,11 @@ BEGIN
 END $$;
 
 -- 9. Nettoyage des données de test
-\echo '9. Nettoyage des données de test:'
+SELECT '9. Nettoyage des données de test:' AS info;
 DELETE FROM public.amortizations 
 WHERE item_name LIKE 'Test %' OR item_name LIKE '%test%';
 
 SELECT '✅ Données de test nettoyées' as status;
 
-\echo '=== FIN SMOKE TEST ==='
-\echo 'Si tous les tests affichent ✅, la migration est réussie.'
+SELECT '=== FIN SMOKE TEST ===' AS info;
+SELECT 'Si tous les tests affichent ✅, la migration est réussie.' AS info;

--- a/supabase/migrations/20250923071017_peaceful_forest.sql
+++ b/supabase/migrations/20250923071017_peaceful_forest.sql
@@ -4,14 +4,13 @@
 -- Ce script valide que toutes les corrections UUID et amortization fonctionnent
 -- Exécution : psql -v ON_ERROR_STOP=1 -f sql/smoke.sql
 
-\echo '🧪 SMOKE TEST - Validation UUID et amortization'
-\echo ''
+SELECT '🧪 SMOKE TEST - Validation UUID et amortization' AS info;
 
 -- ============================================================================
 -- 1. VÉRIFICATION EXTENSION PGCRYPTO
 -- ============================================================================
 
-\echo '1️⃣  Vérification extension pgcrypto...'
+SELECT '1️⃣  Vérification extension pgcrypto...' AS info;
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pgcrypto') THEN
@@ -24,7 +23,7 @@ END $$;
 -- 2. VÉRIFICATION GÉNÉRATION UUID
 -- ============================================================================
 
-\echo '2️⃣  Test génération gen_random_uuid()...'
+SELECT '2️⃣  Test génération gen_random_uuid()...' AS info;
 DO $$
 DECLARE
   test_uuid uuid;
@@ -40,7 +39,7 @@ END $$;
 -- 3. VÉRIFICATION DEFAULT DES COLONNES ID
 -- ============================================================================
 
-\echo '3️⃣  Vérification DEFAULT des colonnes id uuid...'
+SELECT '3️⃣  Vérification DEFAULT des colonnes id uuid...' AS info;
 DO $$
 DECLARE
   table_record RECORD;
@@ -74,7 +73,7 @@ END $$;
 -- 4. VÉRIFICATION ABSENCE DE FONCTIONS UID() PROBLÉMATIQUES
 -- ============================================================================
 
-\echo '4️⃣  Vérification absence de uid() problématique...'
+SELECT '4️⃣  Vérification absence de uid() problématique...' AS info;
 DO $$
 DECLARE
   uid_functions text[];
@@ -97,7 +96,7 @@ END $$;
 -- 5. TEST CONTRAINTE AMORTIZATION
 -- ============================================================================
 
-\echo '5️⃣  Test contrainte useful_life_years >= 1...'
+SELECT '5️⃣  Test contrainte useful_life_years >= 1...' AS info;
 DO $$
 DECLARE
   test_user_id uuid;
@@ -141,7 +140,7 @@ END $$;
 -- 6. TEST INSERTION VALIDE AMORTIZATION
 -- ============================================================================
 
-\echo '6️⃣  Test insertion amortization valide...'
+SELECT '6️⃣  Test insertion amortization valide...' AS info;
 DO $$
 DECLARE
   test_user_id uuid;
@@ -191,7 +190,7 @@ END $$;
 -- 7. TEST AUTO-GÉNÉRATION UUID
 -- ============================================================================
 
-\echo '7️⃣  Test auto-génération UUID sur INSERT...'
+SELECT '7️⃣  Test auto-génération UUID sur INSERT...' AS info;
 DO $$
 DECLARE
   test_user_id uuid;
@@ -231,7 +230,7 @@ END $$;
 -- 8. VÉRIFICATION CONTRAINTES DE QUALITÉ
 -- ============================================================================
 
-\echo '8️⃣  Vérification contraintes de qualité...'
+SELECT '8️⃣  Vérification contraintes de qualité...' AS info;
 DO $$
 DECLARE
   constraint_count integer;
@@ -253,7 +252,7 @@ END $$;
 -- 9. NETTOYAGE FINAL
 -- ============================================================================
 
-\echo '9️⃣  Nettoyage final des données de test...'
+SELECT '9️⃣  Nettoyage final des données de test...' AS info;
 DO $$
 DECLARE
   cleanup_count integer;
@@ -278,13 +277,11 @@ BEGIN
   RAISE NOTICE '✅ Nettoyage final terminé';
 END $$;
 
-\echo ''
-\echo '🎯 SMOKE TEST TERMINÉ - Toutes les vérifications passées ✅'
-\echo '   - Extension pgcrypto activée'
-\echo '   - Génération gen_random_uuid() fonctionnelle'
-\echo '   - DEFAULT des colonnes id corrigés'
-\echo '   - Aucune fonction uid() problématique'
-\echo '   - Contraintes de qualité en place'
-\echo '   - Auto-génération UUID validée'
-\echo '   - Données invalides nettoyées'
-\echo ''
+SELECT '🎯 SMOKE TEST TERMINÉ - Toutes les vérifications passées ✅' AS info;
+SELECT '   - Extension pgcrypto activée' AS info;
+SELECT '   - Génération gen_random_uuid() fonctionnelle' AS info;
+SELECT '   - DEFAULT des colonnes id corrigés' AS info;
+SELECT '   - Aucune fonction uid() problématique' AS info;
+SELECT '   - Contraintes de qualité en place' AS info;
+SELECT '   - Auto-génération UUID validée' AS info;
+SELECT '   - Données invalides nettoyées' AS info;


### PR DESCRIPTION
## Summary
- remove the remaining `\set ON_ERROR_STOP` directives from the smoke test and rollback SQL scripts
- replace all `\echo` output helpers with regular `SELECT` statements so the scripts stay informative without relying on psql meta-commands

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3ad8529588325b88a9783b2473414