### PR TITLE
Add SQL smoke and seed scripts compatible with Bolt

### DIFF
--- a/sql/seed_dev_amortization.sql
+++ b/sql/seed_dev_amortization.sql
@@ -1,0 +1,148 @@
+-- ============================================================================
+-- Seed de développement pour les amortissements PilotImmo
+-- ============================================================================
+-- Ce script crée un jeu de données minimal pour travailler en local :
+--   - Un utilisateur de démonstration (public.users)
+--   - Une propriété rattachée à cet utilisateur (public.properties)
+--   - Un amortissement valide lié à la propriété (public.amortizations)
+--
+-- Le script est entièrement idempotent et n'utilise aucune méta-commande psql.
+-- ============================================================================
+
+SELECT '🌱 Seed développement amortizations' AS info;
+
+DO $$
+DECLARE
+  demo_uid constant text := 'demo-user-pilotimmo';
+  demo_email constant text := 'demo@pilotimmo.dev';
+  demo_user_id uuid;
+  demo_property_id uuid;
+  has_created_by boolean;
+BEGIN
+  -- Vérifier la présence des tables nécessaires
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'users'
+  ) THEN
+    RAISE NOTICE '⚠️  Table public.users absente, seed annulé';
+    RETURN;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'properties'
+  ) THEN
+    RAISE NOTICE '⚠️  Table public.properties absente, seed annulé';
+    RETURN;
+  END IF;
+
+  -- Récupérer ou créer l'utilisateur de démo
+  SELECT id INTO demo_user_id
+  FROM public.users
+  WHERE uid = demo_uid
+  LIMIT 1;
+
+  IF demo_user_id IS NULL THEN
+    INSERT INTO public.users (uid, email, display_name, subscription)
+    VALUES (demo_uid, demo_email, 'Utilisateur Démo', 'free')
+    RETURNING id INTO demo_user_id;
+
+    RAISE NOTICE '✅ Utilisateur de démo créé (uid=%)', demo_uid;
+  ELSE
+    RAISE NOTICE 'ℹ️  Utilisateur de démo déjà présent (uid=%)', demo_uid;
+  END IF;
+
+  -- Vérifier la présence de la colonne created_by sur properties
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'properties'
+      AND column_name = 'created_by'
+  ) INTO has_created_by;
+
+  -- Récupérer ou créer une propriété de démo
+  SELECT id INTO demo_property_id
+  FROM public.properties
+  WHERE user_id = demo_uid
+  ORDER BY created_at
+  LIMIT 1;
+
+  IF demo_property_id IS NULL THEN
+    IF has_created_by THEN
+      INSERT INTO public.properties (
+        user_id, created_by, address, start_date, monthly_rent,
+        status, description, type
+      ) VALUES (
+        demo_uid,
+        demo_uid,
+        '123 Rue du Smoke Test, 75000 Paris',
+        CURRENT_DATE,
+        950,
+        'active',
+        'Bien de démonstration créé par sql/seed_dev_amortization.sql',
+        'apartment'
+      )
+      RETURNING id INTO demo_property_id;
+    ELSE
+      INSERT INTO public.properties (
+        user_id, address, start_date, monthly_rent,
+        status, description, type
+      ) VALUES (
+        demo_uid,
+        '123 Rue du Smoke Test, 75000 Paris',
+        CURRENT_DATE,
+        950,
+        'active',
+        'Bien de démonstration créé par sql/seed_dev_amortization.sql',
+        'apartment'
+      )
+      RETURNING id INTO demo_property_id;
+    END IF;
+
+    RAISE NOTICE '✅ Propriété de démo créée (id=%)', demo_property_id;
+  ELSE
+    RAISE NOTICE 'ℹ️  Propriété de démo déjà présente (id=%)', demo_property_id;
+  END IF;
+
+  -- Créer un amortissement de démo si nécessaire
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'amortizations'
+  ) THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM public.amortizations
+      WHERE property_id = demo_property_id
+    ) THEN
+      INSERT INTO public.amortizations (
+        user_id,
+        property_id,
+        item_name,
+        category,
+        purchase_date,
+        purchase_amount,
+        useful_life_years,
+        status,
+        notes
+      ) VALUES (
+        demo_uid,
+        demo_property_id,
+        'Mobilier de démonstration',
+        'mobilier',
+        CURRENT_DATE - INTERVAL '180 days',
+        2400,
+        10,
+        'active',
+        'Créé automatiquement par sql/seed_dev_amortization.sql'
+      );
+
+      RAISE NOTICE '✅ Amortissement de démo créé pour la propriété %', demo_property_id;
+    ELSE
+      RAISE NOTICE 'ℹ️  Amortissement de démo déjà présent pour la propriété %', demo_property_id;
+    END IF;
+  ELSE
+    RAISE NOTICE '⚠️  Table public.amortizations absente, étape ignorée';
+  END IF;
+END;
+$$;
+
+SELECT '✅ Seed développement terminé' AS status;

--- a/sql/smoke.sql
+++ b/sql/smoke.sql
@@ -1,0 +1,162 @@
+-- ============================================================================
+-- Smoke test Postgres/Supabase pour PilotImmo
+-- ============================================================================
+-- Ce script s'exécute en SQL pur (aucune méta-commande psql) afin d'être
+-- compatible avec les outils comme Supabase SQL Editor ou Bolt.
+-- Il vérifie les points essentiels suivants :
+--   1. Extension pgcrypto disponible
+--   2. Génération d'UUID via gen_random_uuid()
+--   3. Cohérence du schéma properties (colonnes user_id et created_by)
+--   4. Absence de placeholders string dans les colonnes critiques
+--   5. Contrainte useful_life_years >= 1 présente sur amortizations
+--   6. Aucune donnée amortizations avec useful_life_years <= 0
+-- ============================================================================
+
+SELECT '🧪 SMOKE TEST - PilotImmo (SQL pur)' AS info;
+
+-- 1. Vérifier que pgcrypto est disponible
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_extension WHERE extname = 'pgcrypto'
+  ) THEN
+    RAISE EXCEPTION '❌ Extension pgcrypto non activée';
+  END IF;
+
+  RAISE NOTICE '✅ Extension pgcrypto active';
+END;
+$$;
+
+-- 2. Vérifier que gen_random_uuid() fonctionne
+DO $$
+DECLARE
+  test_uuid uuid;
+BEGIN
+  SELECT gen_random_uuid() INTO test_uuid;
+  IF test_uuid IS NULL THEN
+    RAISE EXCEPTION '❌ gen_random_uuid() a retourné NULL';
+  END IF;
+
+  RAISE NOTICE '✅ gen_random_uuid() fonctionne (%).', test_uuid;
+END;
+$$;
+
+-- 3. Vérifier la présence de properties.user_id et properties.created_by
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'properties'
+  ) THEN
+    RAISE EXCEPTION '❌ Table public.properties absente';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'properties' AND column_name = 'user_id'
+  ) THEN
+    RAISE EXCEPTION '❌ Colonne properties.user_id manquante';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'properties' AND column_name = 'created_by'
+  ) THEN
+    RAISE EXCEPTION '❌ Colonne properties.created_by manquante';
+  END IF;
+
+  RAISE NOTICE '✅ Table properties et colonnes user_id/created_by présentes';
+END;
+$$;
+
+-- 4. Vérifier qu'aucun placeholder string ne subsiste dans les colonnes critiques
+DO $$
+DECLARE
+  col RECORD;
+  placeholder_count integer;
+BEGIN
+  FOR col IN
+    SELECT table_name, column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND column_name IN ('id', 'user_id', 'created_by', 'property_id')
+  LOOP
+    EXECUTE format(
+      'SELECT COUNT(*) FROM public.%I WHERE (%I)::text ~ ''^(test-|placeholder)''
+         OR (%I)::text IN (''test-user-id'', ''test-property-id'')',
+      col.table_name, col.column_name, col.column_name
+    )
+    INTO placeholder_count;
+
+    IF placeholder_count > 0 THEN
+      RAISE EXCEPTION '❌ Placeholders détectés dans %.% (% occurrences)',
+        col.table_name, col.column_name, placeholder_count;
+    END IF;
+  END LOOP;
+
+  RAISE NOTICE '✅ Aucun placeholder string détecté dans les colonnes critiques';
+END;
+$$;
+
+-- 5. Vérifier que la contrainte useful_life_years >= 1 est bien présente
+DO $$
+DECLARE
+  constraint_ok boolean;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'amortizations'
+  ) THEN
+    RAISE NOTICE '⚠️  Table amortizations absente, test ignoré';
+    RETURN;
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    WHERE n.nspname = 'public'
+      AND t.relname = 'amortizations'
+      AND (
+        pg_get_constraintdef(c.oid) ILIKE '%useful_life_years%>= 1%'
+        OR pg_get_constraintdef(c.oid) ILIKE '%useful_life_years%> 0%'
+      )
+  ) INTO constraint_ok;
+
+  IF NOT constraint_ok THEN
+    RAISE EXCEPTION '❌ Contrainte useful_life_years >= 1 absente sur amortizations';
+  END IF;
+
+  RAISE NOTICE '✅ Contrainte useful_life_years >= 1 active sur amortizations';
+END;
+$$;
+
+-- 6. Vérifier qu'aucune ligne amortizations n'a useful_life_years <= 0
+DO $$
+DECLARE
+  invalid_count integer;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'amortizations'
+      AND column_name = 'useful_life_years'
+  ) THEN
+    RAISE NOTICE '⚠️  Colonne useful_life_years absente, test ignoré';
+    RETURN;
+  END IF;
+
+  SELECT COUNT(*) INTO invalid_count
+  FROM public.amortizations
+  WHERE useful_life_years IS NOT NULL AND useful_life_years <= 0;
+
+  IF invalid_count > 0 THEN
+    RAISE EXCEPTION '❌ useful_life_years <= 0 détectés (% lignes)', invalid_count;
+  END IF;
+
+  RAISE NOTICE '✅ Toutes les lignes amortizations ont useful_life_years >= 1';
+END;
+$$;
+
+SELECT '✅ Smoke test SQL terminé avec succès' AS status;

--- a/sql/smoke_test_placeholders.sql
+++ b/sql/smoke_test_placeholders.sql
@@ -1,0 +1,96 @@
+-- ============================================================================
+-- Smoke test : détection des placeholders et garde-fous amortization
+-- ============================================================================
+-- Ce script vérifie :
+--   1. Qu'aucune colonne critique ne contient de placeholders (test-*, placeholder-*)
+--   2. Qu'aucun amortissement ne possède useful_life_years <= 0
+--   3. Que les enregistrements de démonstration créés par le seed existent
+-- ============================================================================
+
+SELECT '📋 Smoke test placeholders & amortization' AS info;
+
+-- 1. Vérifier l'absence de placeholders string
+DO $$
+DECLARE
+  rec RECORD;
+  placeholder_hits integer;
+  total_hits integer := 0;
+BEGIN
+  FOR rec IN
+    SELECT table_name, column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND column_name IN ('id', 'user_id', 'created_by', 'property_id', 'tenant_id')
+  LOOP
+    EXECUTE format(
+      'SELECT COUNT(*) FROM public.%I WHERE (%I)::text ~ ''^(test-|placeholder)''
+         OR (%I)::text IN (''test-user-id'', ''test-property-id'')',
+      rec.table_name, rec.column_name, rec.column_name
+    ) INTO placeholder_hits;
+
+    IF placeholder_hits > 0 THEN
+      total_hits := total_hits + placeholder_hits;
+      RAISE WARNING '❌ % placeholders détectés dans %.%', placeholder_hits, rec.table_name, rec.column_name;
+    END IF;
+  END LOOP;
+
+  IF total_hits > 0 THEN
+    RAISE EXCEPTION '❌ % valeurs placeholder détectées dans la base', total_hits;
+  END IF;
+
+  RAISE NOTICE '✅ Aucun placeholder string détecté';
+END;
+$$;
+
+-- 2. Vérifier les amortissements (useful_life_years >= 1)
+DO $$
+DECLARE
+  invalid_rows integer := 0;
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'amortizations'
+  ) THEN
+    SELECT COUNT(*) INTO invalid_rows
+    FROM public.amortizations
+    WHERE useful_life_years IS NOT NULL AND useful_life_years <= 0;
+
+    IF invalid_rows > 0 THEN
+      RAISE EXCEPTION '❌ % amortizations avec useful_life_years <= 0 détectés', invalid_rows;
+    END IF;
+
+    RAISE NOTICE '✅ Contraintes amortization respectées (useful_life_years >= 1)';
+  ELSE
+    RAISE NOTICE '⚠️  Table amortizations absente, test ignoré';
+  END IF;
+END;
+$$;
+
+-- 3. Vérifier la présence du seed de démonstration
+DO $$
+DECLARE
+  demo_uid constant text := 'demo-user-pilotimmo';
+  has_user boolean;
+  has_property boolean;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM public.users WHERE uid = demo_uid
+  ) INTO has_user;
+
+  IF NOT has_user THEN
+    RAISE EXCEPTION '❌ Utilisateur de démo (% ) absent : exécuter sql/seed_dev_amortization.sql', demo_uid;
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.properties WHERE user_id = demo_uid
+  ) INTO has_property;
+
+  IF NOT has_property THEN
+    RAISE EXCEPTION '❌ Propriété de démo absente pour l''utilisateur %', demo_uid;
+  END IF;
+
+  RAISE NOTICE '✅ Seed de démonstration présent (user & property)';
+END;
+$$;
+
+SELECT '✅ Smoke test placeholders terminé' AS status;


### PR DESCRIPTION
## Summary
- add a pure SQL smoke test that verifies pgcrypto, UUID defaults and amortization guards without using psql meta commands
- add an idempotent development seed script for demo data compatible with Supabase and Bolt
- add a placeholder smoke test to detect bad UUID strings and confirm seed presence

## Testing
- not run (database required)


------
https://chatgpt.com/codex/tasks/task_e_68d3b04647a483259334aa60fa39d445