### PR TITLE
fix: ensure amortization smoke tests use valid UUIDs

### DIFF
--- a/supabase/migrations/20250922104029_frosty_lodge.sql
+++ b/supabase/migrations/20250922104029_frosty_lodge.sql
@@ -8,6 +8,27 @@
   4. Cas limites et erreurs
 */
 
+-- Préparer une propriété de test valide (UUID déterministe)
+INSERT INTO properties (
+  id,
+  user_id,
+  address,
+  start_date,
+  monthly_rent,
+  status,
+  type
+)
+VALUES (
+  '00000000-0000-0000-0000-000000000001',
+  'test-user-id',
+  'Test property for amortization checks',
+  CURRENT_DATE,
+  0,
+  'active',
+  'apartment'
+)
+ON CONFLICT (id) DO NOTHING;
+
 -- Test 1: Vérification des fonctions
 SELECT 'Test 1: Fonction amortization_annual' as test_name;
 
@@ -51,7 +72,7 @@ BEGIN
       user_id, property_id, item_name, category,
       purchase_date, purchase_amount, useful_life_years
     ) VALUES (
-      'test-user-id', 'test-property-id', 'Test Item', 'mobilier',
+      'test-user-id', '00000000-0000-0000-0000-000000000001', 'Test Item', 'mobilier',
       CURRENT_DATE, 1000, 0
     );
     RAISE NOTICE 'ERREUR: Insertion avec years=0 devrait échouer';
@@ -72,7 +93,7 @@ INSERT INTO amortizations (
   purchase_date, purchase_amount, useful_life_years,
   accumulated_amortization, status
 ) VALUES (
-  'test-user-id', 'test-property-id', 'Test Item Valid', 'mobilier',
+  'test-user-id', '00000000-0000-0000-0000-000000000001', 'Test Item Valid', 'mobilier',
   CURRENT_DATE, 1000, 10, 0, 'active'
 ) RETURNING 
   item_name,
@@ -164,11 +185,11 @@ INSERT INTO amortizations (
   user_id, property_id, item_name, category,
   purchase_date, purchase_amount, useful_life_years, status
 ) VALUES 
-  ('test-user-id', 'test-property-id', 'Canapé', 'mobilier', CURRENT_DATE, 800, 10, 'active'),
-  ('test-user-id', 'test-property-id', 'Réfrigérateur', 'electromenager', CURRENT_DATE, 600, 5, 'active'),
-  ('test-user-id', 'test-property-id', 'Ordinateur', 'informatique', CURRENT_DATE, 1200, 3, 'active'),
-  ('test-user-id', 'test-property-id', 'Cuisine équipée', 'amenagement', CURRENT_DATE, 5000, 15, 'active'),
-  ('test-user-id', 'test-property-id', 'Rénovation salle de bain', 'travaux', CURRENT_DATE, 8000, 20, 'active')
+  ('test-user-id', '00000000-0000-0000-0000-000000000001', 'Canapé', 'mobilier', CURRENT_DATE, 800, 10, 'active'),
+  ('test-user-id', '00000000-0000-0000-0000-000000000001', 'Réfrigérateur', 'electromenager', CURRENT_DATE, 600, 5, 'active'),
+  ('test-user-id', '00000000-0000-0000-0000-000000000001', 'Ordinateur', 'informatique', CURRENT_DATE, 1200, 3, 'active'),
+  ('test-user-id', '00000000-0000-0000-0000-000000000001', 'Cuisine équipée', 'amenagement', CURRENT_DATE, 5000, 15, 'active'),
+  ('test-user-id', '00000000-0000-0000-0000-000000000001', 'Rénovation salle de bain', 'travaux', CURRENT_DATE, 8000, 20, 'active')
 ON CONFLICT DO NOTHING;
 
 -- Vérifier les calculs pour chaque catégorie
@@ -185,5 +206,6 @@ ORDER BY category, item_name;
 
 -- Nettoyage des données de test
 DELETE FROM amortizations WHERE user_id = 'test-user-id';
+DELETE FROM properties WHERE id = '00000000-0000-0000-0000-000000000001';
 
 SELECT 'Tests terminés avec succès!' as final_result;

--- a/supabase/migrations/20250924052557_mellow_glitter.sql
+++ b/supabase/migrations/20250924052557_mellow_glitter.sql
@@ -120,31 +120,31 @@ DO $$
 BEGIN
   -- Remove any records with test placeholders in UUID columns
   IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'amortizations') THEN
-    DELETE FROM amortizations 
-    WHERE user_id = 'test-user-id' 
-       OR property_id = 'test-property-id'
+    DELETE FROM amortizations
+    WHERE user_id = 'test-user-id'
+       OR property_id::text = 'test-property-id'
        OR useful_life_years = 0;
     RAISE NOTICE '✅ Cleaned up invalid amortizations data';
   END IF;
 
   IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'revenues') THEN
-    DELETE FROM revenues 
-    WHERE user_id = 'test-user-id' 
-       OR property_id = 'test-property-id';
+    DELETE FROM revenues
+    WHERE user_id = 'test-user-id'
+       OR property_id::text = 'test-property-id';
     RAISE NOTICE '✅ Cleaned up invalid revenues data';
   END IF;
 
   IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'expenses') THEN
-    DELETE FROM expenses 
-    WHERE user_id = 'test-user-id' 
-       OR property_id = 'test-property-id';
+    DELETE FROM expenses
+    WHERE user_id = 'test-user-id'
+       OR property_id::text = 'test-property-id';
     RAISE NOTICE '✅ Cleaned up invalid expenses data';
   END IF;
 
   IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'tenants') THEN
-    DELETE FROM tenants 
-    WHERE user_id = 'test-user-id' 
-       OR property_id = 'test-property-id';
+    DELETE FROM tenants
+    WHERE user_id = 'test-user-id'
+       OR property_id::text = 'test-property-id';
     RAISE NOTICE '✅ Cleaned up invalid tenants data';
   END IF;
 

--- a/supabase/migrations/20250924053516_lively_queen.sql
+++ b/supabase/migrations/20250924053516_lively_queen.sql
@@ -28,25 +28,25 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
 DO $$
 BEGIN
   -- Supprimer les amortizations avec placeholders string ou useful_life_years <= 0
-  DELETE FROM public.amortizations 
-  WHERE user_id = 'test-user-id' 
-     OR property_id = 'test-property-id'
+  DELETE FROM public.amortizations
+  WHERE user_id = 'test-user-id'
+     OR property_id::text = 'test-property-id'
      OR useful_life_years <= 0;
   
   -- Supprimer les revenues avec placeholders string
-  DELETE FROM public.revenues 
-  WHERE user_id = 'test-user-id' 
-     OR property_id = 'test-property-id';
+  DELETE FROM public.revenues
+  WHERE user_id = 'test-user-id'
+     OR property_id::text = 'test-property-id';
   
   -- Supprimer les expenses avec placeholders string
-  DELETE FROM public.expenses 
-  WHERE user_id = 'test-user-id' 
-     OR property_id = 'test-property-id';
+  DELETE FROM public.expenses
+  WHERE user_id = 'test-user-id'
+     OR property_id::text = 'test-property-id';
   
   -- Supprimer les tenants avec placeholders string
-  DELETE FROM public.tenants 
-  WHERE user_id = 'test-user-id' 
-     OR property_id = 'test-property-id';
+  DELETE FROM public.tenants
+  WHERE user_id = 'test-user-id'
+     OR property_id::text = 'test-property-id';
   
   -- Supprimer les properties avec placeholders string
   DELETE FROM public.properties 


### PR DESCRIPTION
## Summary
- seed the amortization test migration with a deterministic UUID-based property and clean it up afterwards
- keep cleanup migrations casting property_id to text before checking for placeholder values to avoid UUID parsing errors

## Testing
- not run (SQL migrations only)


------
https://chatgpt.com/codex/tasks/task_e_68d3df0a45908325a1da3786b2c85141